### PR TITLE
INTG-237: replace 'Jenkins' with 'CI/CD'

### DIFF
--- a/api-client-util/src/main/java/com/takipi/api/client/util/cicd/ProcessQualityGates.java
+++ b/api-client-util/src/main/java/com/takipi/api/client/util/cicd/ProcessQualityGates.java
@@ -37,7 +37,7 @@ public class ProcessQualityGates {
 		if ((deploymentsActiveWindow == null) ||
 			(deploymentsActiveWindow.getFirst() == null)) {
 			throw new IllegalStateException("Deployments " + Arrays.toString(input.deployments.toArray())
-					+ " not found. Please ensure your collector and Jenkins configuration are pointing to the same environment.");
+					+ " not found. Please ensure your collector and CI/CD configuration are pointing to the same environment.");
 		}
 		
 		DateTime deploymentStart = deploymentsActiveWindow.getFirst();


### PR DESCRIPTION
Replace word "Jenkins" with "CI/CD" as this method is used across multiple CI/CD tools.